### PR TITLE
feat: create logic for updating team points

### DIFF
--- a/src/interfaces/GameInterfaces.ts
+++ b/src/interfaces/GameInterfaces.ts
@@ -16,3 +16,8 @@ export interface IJoinGameRoomInfo {
   roomId: string;
   team: 'teamA' | 'teamB';
 }
+
+export interface gameRoomPoints {
+  teamAPoints: number;
+  teamBPoints: number;
+}

--- a/src/repositories/roomRepository.ts
+++ b/src/repositories/roomRepository.ts
@@ -27,6 +27,11 @@ class RoomRepository {
     const room = await databases.gameRoom;
     await room.insert(gameRoom);
   }
+
+  async updateEndGameRoomState(gameRoom: GameRoomDto): Promise<void>{
+    const room = await databases.gameRoom;
+    await room.insert(gameRoom);
+  }
 }
 export default new RoomRepository();
 export { RoomRepository };

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -1,4 +1,5 @@
-import { GameRoom, IJoinGameRoomInfo } from '../interfaces/GameInterfaces';
+import { GameRoom, gameRoomPoints } from '../interfaces/GameInterfaces';
+import { IJoinGameRoomInfo } from '../interfaces/GameInterfaces';
 import { RoomRepository } from '../repositories/roomRepository';
 import roomRepository from '../repositories/roomRepository';
 import { CustomError } from '../helpers/CustomError';
@@ -95,7 +96,16 @@ class RoomService {
     gameRoom.updatedAt = new Date().toISOString();
     this.roomRepository.leave(gameRoom);
   }
-}
 
+  async updateEndGameRoomState(
+    roomId: string,
+    gameRoomPoints: gameRoomPoints
+  ): Promise<void> {
+    const gameRoom = await this.roomRepository.get(roomId);
+    gameRoom.teamAPoints = gameRoomPoints.teamAPoints;
+    gameRoom.teamBPoints = gameRoomPoints.teamBPoints;
+    await this.roomRepository.updateEndGameRoomState(gameRoom);
+  }
+}
 export default new RoomService(roomRepository);
 export { RoomService };


### PR DESCRIPTION
Add a method to roomServices for updating a gameRoom after the match ends, in order to update the points and store the match in the database.

This feature will be used by game mechancs.