### PR TITLE
[fix] Cant steal if no hint was given for last word in turn

### DIFF
--- a/src/helpers/sendNewWordTo.ts
+++ b/src/helpers/sendNewWordTo.ts
@@ -38,7 +38,7 @@ export const sendNewWordTo = (
       
       gameState.currentWord = getUniqueWord(gameState.wordsHistory);
       gameState.wordGuessed = false;
-
+      gameState.hinted = false;
       if (socket.id === gameState.currentPlayer)
         socket.emit('new-word', gameState.currentWord);
       else

--- a/src/interfaces/GameInterfaces.ts
+++ b/src/interfaces/GameInterfaces.ts
@@ -31,6 +31,7 @@ export interface GameState {
   wordsHistory: string[];
   currentPlayer: string; //socket id of player giving hints
   finishedTurns: number;
+  hinted: boolean; // whether a hint has been given for current word or not
 }
 
 export interface IJoinGameRoomInfo {

--- a/src/services/game/playerReady.ts
+++ b/src/services/game/playerReady.ts
@@ -42,6 +42,7 @@ export const playerReady = (socket: Socket) => {
           wordsHistory: [],
           currentPlayer: '',
           finishedTurns: 0,
+          hinted: false,
         });
       }
       // getting the room where user want to join

--- a/src/services/game/sendHint.ts
+++ b/src/services/game/sendHint.ts
@@ -37,6 +37,7 @@ export const sendHint = (socket: Socket, io: Server) => {
               }
           });
           // show everyone the hint
+          gameState.hinted = true;
           io.to(userInfo.roomId).emit('show-hint', `${userInfo.username} hinted: ${body.hint}`);
         } 
       }

--- a/src/services/game/startGame.ts
+++ b/src/services/game/startGame.ts
@@ -56,7 +56,7 @@ export const startGame = (socket: Socket, io: Server) => {
 
         // Logic for word stealing (Opposite team can try to guess last word if it wasn't guessed yet)
         const stealWord = () => {
-          if (!gameState.wordGuessed) {
+          if (!gameState.wordGuessed && gameState.hinted) {
 
             // pauses turn change
             clearInterval(turnChanger);


### PR DESCRIPTION
If a turn ends and the team didn't guess the word, the other team will only get a chance to steal if at least one hint was given for that word.